### PR TITLE
Fixed link to Serum/Anchor installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ First, install dependencies:
 $ yarn install
 ```
 
-And install Anchor by following the [instructions here](https://project-serum.github.io/anchor/getting-started/installation.html).
+And install Anchor by following the [instructions here](https://github.com/coral-xyz/anchor/blob/master/docs/src/getting-started/installation.md).
 
 Build the program:
 


### PR DESCRIPTION
Serum changed repo from Serum to [Coral](https://github.com/coral-xyz). 
- Updated link to Anchor Installation guide.